### PR TITLE
Ant 2239 generate cmake build

### DIFF
--- a/build/clidll-usage/Debug/test.txt
+++ b/build/clidll-usage/Debug/test.txt
@@ -1,0 +1,5 @@
+Cpus: ARMv7, ARM64, X86, X64
+GraphicsAPI: Vulkan, GLES3, OpenGl 
+Gpus: Adreno, Mali, PowerVR, Tegra, Intel
+EntryPoint: Activity, GameActivity
+Suites: Editor, PlayMode, StandaloneX86, StandaloneX64

--- a/build_and_run.cmd
+++ b/build_and_run.cmd
@@ -1,0 +1,7 @@
+cmake -DCMAKE_BUILD_TYPE=Release -S . -B build
+cmake --build build
+
+copy build\clidll\Debug\pict.dll build\clidll-usage\Debug\pict.dll
+
+pushd build\api-usage\Debug && call pictapisamples.exe && popd
+pushd build\clidll-usage\Debug && call pictclidllusage.exe && popd

--- a/cli/pict.cpp
+++ b/cli/pict.cpp
@@ -127,6 +127,7 @@ int __cdecl wmain
 }
 
 #if !defined(_MSC_VER)
+#if !defined(TEST_PROJECT)
 //
 // Gcc doesn't understand wchar_t args
 // This entry point is a workaround for compiling with a non-MS compiler
@@ -176,4 +177,5 @@ int main
 
     return( ret );
 }
+#endif
 #endif


### PR DESCRIPTION
This PR allows to run tests separately by disabling the macos main function in the pict cli code using a define.

The DEFINE is provided for the test project only, via BEE.