### PR TITLE
Ant 2231 deterministic rand

### DIFF
--- a/api/generator.h
+++ b/api/generator.h
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <functional>
 #include <cassert>
+#include <random>
 
 //
 // Logging facility
@@ -35,6 +36,8 @@ wofstream logfile;
 #else
 #define DOUT(arg)
 #endif
+
+#define PICT_DEFAULT_PARAMETER_RANDOM_SEED  0
 
 //
 // due to discrepancies between different implementations of STL, the following
@@ -379,6 +382,7 @@ public:
     {
          // result params must have order = 1
         if ( m_expResultParam ) m_order = 1;
+        m_randgenerator.seed(PICT_DEFAULT_PARAMETER_RANDOM_SEED);
     }
     virtual ~Parameter() {}
 
@@ -462,6 +466,7 @@ private:
     size_t m_currentValue = 0;  // current iteration's value cache
     int    m_valueCount;        // how many values parameter has
     bool   m_expResultParam;    // is this a special, result inducing param
+    std::mt19937    m_randgenerator;
 
     bool m_bound;         // variable to use in iteration - is this bound yet?
     bool m_pending;       // have we put it on work list yet this iteration?
@@ -542,7 +547,7 @@ public:
     void SetRandomSeed( long seed )
     {
         m_randomSeed = seed;
-        srand( m_randomSeed );
+        m_randgenerator.seed(m_randomSeed);
         for( auto & submodel : m_submodels ) submodel->SetRandomSeed( m_randomSeed );
     }
 
@@ -602,7 +607,7 @@ private:
     RowSeedCollection      m_rowSeeds;
     std::deque<Parameter*> m_worklist;
     ResultCollection       m_results;
-
+    std::mt19937           m_randgenerator;
     std::wstring m_id;
 
     int  m_order;

--- a/api/model.cpp
+++ b/api/model.cpp
@@ -258,7 +258,7 @@ void Model::gcd( ComboCollection &vecCombo )
                             // if number of zeros ties up with some previous choice, pick randomly
                             else if( open == maxZeros
                                  &&  maxZeros > 0
-                                 &&  !( rand() % ++ties ) )
+                                 &&  !( m_randgenerator() % ++ties ) )
                             {
                                 choice = cidx;
                             }
@@ -274,7 +274,7 @@ void Model::gcd( ComboCollection &vecCombo )
                             else if( maxZeros == 0
                                  &&  match > 0
                                  &&  match == maxMatch
-                                 &&  !( rand() % ++ties ) )
+                                 &&  !( m_randgenerator() % ++ties ) )
                             {
                                 choice = cidx;
                             }
@@ -299,7 +299,7 @@ void Model::gcd( ComboCollection &vecCombo )
                                 // Pick a value using weighted random choice
                                 int weight = vecCombo[ choice ]->Weight( vidx );
                                 totalWeight += weight;
-                                if( rand() % totalWeight < weight )
+                                if( m_randgenerator() % totalWeight < weight )
                                 {
                                     bestValue = vidx;
                                 }
@@ -331,7 +331,7 @@ void Model::gcd( ComboCollection &vecCombo )
                         }
 #endif
                         assert( !candidates.empty() );
-                        int zeroVal = candidates[ rand() % candidates.size() ];
+                        int zeroVal = candidates[ m_randgenerator() % candidates.size() ];
                         DOUT( L"Chose value " << zeroVal << L", unbound count was " << unbound << L".\n" );
                         // Bind the values corresponding to the zero
                         unbound -= vecCombo[ choice ]->Bind( zeroVal, worklist );
@@ -984,7 +984,7 @@ Exclusion Model::generateRandomRow()
         {
             sum += ( *ip )->GetWeight( i );
         }
-        int idx = rand() % sum;
+        int idx = m_randgenerator() % sum;
 
         int n;
         int val = 0;

--- a/api/parameter.cpp
+++ b/api/parameter.cpp
@@ -117,7 +117,7 @@ int Parameter::PickValue()
                     bestValue = value;
                 }
             }
-            else if (totalZeros == maxTotal && !(m_randgenerator() % ++bestValueCount))
+            else if (totalZeros == maxTotal && !((m_randgenerator() + 1) % ++bestValueCount))
             {
                 bestValue = value;
                 maxTotal  = totalZeros;

--- a/api/parameter.cpp
+++ b/api/parameter.cpp
@@ -112,12 +112,12 @@ int Parameter::PickValue()
                 // Arbitrary choice - we already have this parameter covered
                 // Use weights if they exist
                 bestValueCount += GetWeight(value);
-                if (rand() % bestValueCount < GetWeight(value))
+                if (m_randgenerator() % bestValueCount < GetWeight(value))
                 {
                     bestValue = value;
                 }
             }
-            else if (totalZeros == maxTotal && !(rand() % ++bestValueCount))
+            else if (totalZeros == maxTotal && !(m_randgenerator() % ++bestValueCount))
             {
                 bestValue = value;
                 maxTotal  = totalZeros;

--- a/build/clidll-usage/Debug/test.txt
+++ b/build/clidll-usage/Debug/test.txt
@@ -1,0 +1,5 @@
+Cpus: ARMv7, ARM64, X86, X64
+GraphicsAPI: Vulkan, GLES3, OpenGl 
+Gpus: Adreno, Mali, PowerVR, Tegra, Intel
+EntryPoint: Activity, GameActivity
+Suites: Editor, PlayMode, StandaloneX86, StandaloneX64

--- a/build_and_run.cmd
+++ b/build_and_run.cmd
@@ -1,0 +1,7 @@
+cmake -DCMAKE_BUILD_TYPE=Release -S . -B build
+cmake --build build
+
+copy build\clidll\Debug\pict.dll build\clidll-usage\Debug\pict.dll
+
+pushd build\api-usage\Debug && call pictapisamples.exe && popd
+pushd build\clidll-usage\Debug && call pictclidllusage.exe && popd

--- a/cli/pict.cpp
+++ b/cli/pict.cpp
@@ -127,6 +127,7 @@ int __cdecl wmain
 }
 
 #if !defined(_MSC_VER)
+#if !defined(TEST_PROJECT)
 //
 // Gcc doesn't understand wchar_t args
 // This entry point is a workaround for compiling with a non-MS compiler
@@ -176,4 +177,5 @@ int main
 
     return( ret );
 }
+#endif
 #endif


### PR DESCRIPTION
Usage of a implementation dependent randomizer in the Pict generator causes results to be inconsistent between different platforms. The use of a deterministic randomizer solve the issue.